### PR TITLE
Increase disk size on node 2

### DIFF
--- a/terraform/dev3.tfvars
+++ b/terraform/dev3.tfvars
@@ -36,7 +36,7 @@ mesh_worker_ram_mb = [
 mesh_worker_disk_size = [
   50,
   50,
-  50,
+  150,
   150,
 ]
 mesh_lb_ip        = "10.70.90.145"

--- a/terraform/prod1.tfvars
+++ b/terraform/prod1.tfvars
@@ -37,7 +37,7 @@ mesh_worker_ram_mb = [
 mesh_worker_disk_size = [
   50,
   50,
-  50,
+  150,
   150,
 ]
 mesh_lb_ip        = "10.70.90.156"


### PR DESCRIPTION
Add 100GB to the disk on worker node 2 for a total of 150GB. This is fine to do one at a time because longhorn will simply re-shuffle PV replicas.