### PR TITLE
[datadog] Enable single-step APM for meshdb and meshforms

### DIFF
--- a/ansible/roles/k8s-cluster-helm/templates/datadog_agent.yaml.j2
+++ b/ansible/roles/k8s-cluster-helm/templates/datadog_agent.yaml.j2
@@ -13,7 +13,14 @@ spec:
     clusterName: {{ ENV_NAME }}
   features:
     apm:
-      enabled: true
+	  instrumentation:
+	    enabled: true
+		enabledNamespaces:
+		- meshdb
+		- meshforms
+		libVersions:
+		  js: "5"
+		  python: "2"
     logCollection:
       enabled: true
       containerCollectAll: true


### PR DESCRIPTION
[APM page for meshdb](https://us5.datadoghq.com/apm/services/meshweb/operations/django.request/resources?dependencyMap=qson%3A%28data%3A%28telemetrySelection%3Aall_sources%29%2Cversion%3A%210%29&deployments=qson%3A%28data%3A%28hits%3A%28selected%3Aversion_count%29%2Cerrors%3A%28selected%3Aversion_count%29%2Clatency%3A%2195%2CtopN%3A%215%29%2Cversion%3A%210%29&env=dev3&fromUser=false&groupMapByOperation=null&infrastructure=qson%3A%28data%3A%28viewType%3Apods%29%2Cversion%3A%210%29&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap95%29%2CtopN%3A%215%29%2Cversion%3A%211%29&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%2ClagMetrics%3A%28selectedMetric%3A%21s%2CselectedGroupBy%3A%21s%29%29%2Cversion%3A%211%29&view=spans&start=1725036368629&end=1725039968629&paused=false)
