### PR TITLE
Pin collection due to bug with k3s-ansible

### DIFF
--- a/ansible/collections/requirements.yml
+++ b/ansible/collections/requirements.yml
@@ -2,4 +2,4 @@ collections:
   - name: k3s.orchestration
     source: git+https://github.com/k3s-io/k3s-ansible.git
     type: git
-    version: master
+    version: 3e0c982a95717b76b90a405d53a68a5a6a95d316


### PR DESCRIPTION
A recent [fix in k3s-ansible](https://github.com/k3s-io/k3s-ansible/pull/356) seems to have broken the deployment, pin the version before that while troubleshooting further.