### PR TITLE
Test out change from my k3s-ansible fork

### DIFF
--- a/.github/workflows/deploy_environments.yaml
+++ b/.github/workflows/deploy_environments.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - james/test_k3s_ansible
   workflow_dispatch:
     branches:
       - main
@@ -16,7 +17,7 @@ jobs:
     with:
       environment: dev3
     secrets: inherit
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
 
   deploy_prod1:
     name: Deploy prod1

--- a/.github/workflows/deploy_k8s_cluster.yaml
+++ b/.github/workflows/deploy_k8s_cluster.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.11'
       
       - name: Setup ansible
-        run: pip install ansible && export PATH="$HOME/.local/bin:$PATH" && ansible-galaxy collection install cloud.terraform && ansible-galaxy collection install git+https://github.com/k3s-io/k3s-ansible.git,3e0c982a95717b76b90a405d53a68a5a6a95d316
+        run: pip install ansible && export PATH="$HOME/.local/bin:$PATH" && ansible-galaxy collection install cloud.terraform && ansible-galaxy collection install git+https://github.com/james-otten/k3s-ansible.git,26ea2ffd33b4424117797ac504ba06ffb1fd3733
 
       - name: Setup Terraform with specified version on the runner
         uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # @v3


### PR DESCRIPTION
_Don't actually merge this, wait for https://github.com/k3s-io/k3s-ansible/pull/360 to be merged to and then unpin._

Confirm that my change [here](https://github.com/k3s-io/k3s-ansible/pull/360) fixes the issue this project faced [here](https://github.com/nycmeshnet/k8s-infra/actions/runs/10756493721/job/29829415464#step:14:569)

The issue was it was skipping adding the node token to the `.env` file on an existing cluster (like we have).

I rolled back to a [previous version](https://github.com/nycmeshnet/k8s-infra/pull/20/files) of k3s-ansible to fix the dev environment.