### PR TITLE
Reorder domains to make certbot happy

### DIFF
--- a/terraform/dev3.tfvars
+++ b/terraform/dev3.tfvars
@@ -44,4 +44,5 @@ mesh_gateway      = "10.70.90.1"
 mesh_networkrange = "24"
 mesh_net_block    = "10.70.90.0"
 mesh_external_ip  = "199.170.132.46"
-meshdb_fqdn       = "devdb.nycmesh.net,pgadmin.devdb.nycmesh.net,map.devdb.nycmesh.net,adminmap.devdb.nycmesh.net,los-backend.devdb.nycmesh.net,los.devdb.nycmesh.net,forms.devdb.nycmesh.net,devdb.mesh.nycmesh.net,devforms.mesh.nycmesh.net,devwiki.mesh.nycmesh.net,devadminmap.mesh.nycmesh.net,devmap.mesh.nycmesh.net,devlos.mesh.nycmesh.net,devlos-backend.mesh.nycmesh.net"
+# Add domains to the end
+meshdb_fqdn = "devdb.mesh.nycmesh.net,devforms.mesh.nycmesh.net,devwiki.mesh.nycmesh.net,devadminmap.mesh.nycmesh.net,devmap.mesh.nycmesh.net,devlos.mesh.nycmesh.net,devlos-backend.mesh.nycmesh.net,devdb.nycmesh.net,pgadmin.devdb.nycmesh.net,map.devdb.nycmesh.net,adminmap.devdb.nycmesh.net,los-backend.devdb.nycmesh.net,los.devdb.nycmesh.net,forms.devdb.nycmesh.net"

--- a/terraform/prod1.tfvars
+++ b/terraform/prod1.tfvars
@@ -45,4 +45,5 @@ mesh_gateway      = "10.70.90.1"
 mesh_networkrange = "24"
 mesh_net_block    = "10.70.90.0"
 mesh_external_ip  = "199.170.132.45"
-meshdb_fqdn       = "db.nycmesh.net,pgadmin.db.nycmesh.net,map.db.nycmesh.net,adminmap.db.nycmesh.net,los-backend.db.nycmesh.net,los.nycmesh.net,forms.nycmesh.net,db.mesh.nycmesh.net,forms.mesh.nycmesh.net,wiki2.mesh.nycmesh.net,adminmap.mesh.nycmesh.net,map.mesh.nycmesh.net,los.mesh.nycmesh.net,los-backend.mesh.nycmesh.net"
+# Add domains to the end
+meshdb_fqdn = "db.mesh.nycmesh.net,forms.mesh.nycmesh.net,wiki2.mesh.nycmesh.net,adminmap.mesh.nycmesh.net,map.mesh.nycmesh.net,los.mesh.nycmesh.net,los-backend.mesh.nycmesh.net,db.nycmesh.net,pgadmin.db.nycmesh.net,map.db.nycmesh.net,adminmap.db.nycmesh.net,los-backend.db.nycmesh.net,los.nycmesh.net,forms.nycmesh.net"


### PR DESCRIPTION
Reorder domains to avoid certbot confusion.

```
root@k8s-lb-dev3:~# ls /etc/letsencrypt/live/
README	devdb.mesh.nycmesh.net	devdb.mesh.nycmesh.net-0001
```