### PR TITLE
Turn the http health check into a tcp one

### DIFF
--- a/ansible/roles/k8s-lb/templates/haproxy.cfg
+++ b/ansible/roles/k8s-lb/templates/haproxy.cfg
@@ -42,7 +42,7 @@ frontend meshdb
   http-request redirect scheme https unless { ssl_fc } OR app_letsencrypt
 
 backend k8s
-  option httpchk GET /
+  option tcp-check
 {% for worker in WORKER_IPS.split(';') %}
   server meshworker{{ loop.index }} {{ worker }}:{{ NODE_PORT }} check
 {% endfor %}


### PR DESCRIPTION
As part of https://github.com/nycmeshnet/meshdb/issues/513 and using new domains, the catch all ingress pointing at meshdb nginx is being made more specific. Therefore, switch to a tcp health check so that one service outage does not cause an outage of all services.