### PR TITLE
Cleanup domains

### DIFF
--- a/terraform/dev3.tfvars
+++ b/terraform/dev3.tfvars
@@ -45,4 +45,4 @@ mesh_networkrange = "24"
 mesh_net_block    = "10.70.90.0"
 mesh_external_ip  = "199.170.132.46"
 # Add domains to the end
-meshdb_fqdn = "devdb.mesh.nycmesh.net,devforms.mesh.nycmesh.net,devwiki.mesh.nycmesh.net,devadminmap.mesh.nycmesh.net,devmap.mesh.nycmesh.net,devlos.mesh.nycmesh.net,devlos-backend.mesh.nycmesh.net,devdb.nycmesh.net,pgadmin.devdb.nycmesh.net,map.devdb.nycmesh.net,adminmap.devdb.nycmesh.net,los-backend.devdb.nycmesh.net,los.devdb.nycmesh.net,forms.devdb.nycmesh.net"
+meshdb_fqdn = "devdb.mesh.nycmesh.net,devforms.mesh.nycmesh.net,devwiki.mesh.nycmesh.net,devadminmap.mesh.nycmesh.net,devmap.mesh.nycmesh.net,devdb.nycmesh.net,pgadmin.devdb.nycmesh.net,map.devdb.nycmesh.net,adminmap.devdb.nycmesh.net,los-backend.devdb.nycmesh.net,los.devdb.nycmesh.net,forms.devdb.nycmesh.net"

--- a/terraform/prod1.tfvars
+++ b/terraform/prod1.tfvars
@@ -46,4 +46,4 @@ mesh_networkrange = "24"
 mesh_net_block    = "10.70.90.0"
 mesh_external_ip  = "199.170.132.45"
 # Add domains to the end
-meshdb_fqdn = "db.mesh.nycmesh.net,forms.mesh.nycmesh.net,wiki.nycmesh.net,wiki2.mesh.nycmesh.net,adminmap.mesh.nycmesh.net,map.mesh.nycmesh.net,los.mesh.nycmesh.net,los-backend.mesh.nycmesh.net,db.nycmesh.net,pgadmin.db.nycmesh.net,map.db.nycmesh.net,adminmap.db.nycmesh.net,los-backend.db.nycmesh.net,los.nycmesh.net,forms.nycmesh.net"
+meshdb_fqdn = "db.mesh.nycmesh.net,forms.mesh.nycmesh.net,wiki.nycmesh.net,adminmap.mesh.nycmesh.net,map.mesh.nycmesh.net,db.nycmesh.net,pgadmin.db.nycmesh.net,map.db.nycmesh.net,adminmap.db.nycmesh.net,los-backend.db.nycmesh.net,los.nycmesh.net,forms.nycmesh.net"


### PR DESCRIPTION
Dev:
- `devlos.mesh.nycmesh.net` - fully migrated to `los.devdb.nycmesh.net`
- `devlos-backend.mesh.nycmesh.net` - fully migrated to `los-backend.devdb.nycmesh.net`

Prod:
- `wiki2.mesh.nycmesh.net` - migrated to `wiki.nycmesh.net`, pending final cut-over maintenance window
- `los.mesh.nycmesh.net` - fully migrated to `los.nycmesh.net`
- `los-backend.mesh.nycmesh.net` - fully migrated to `los-backend.db.nycmesh.net`