### PR TITLE
Remove the pgadmin domains

### DIFF
--- a/terraform/dev3.tfvars
+++ b/terraform/dev3.tfvars
@@ -45,4 +45,4 @@ mesh_networkrange = "24"
 mesh_net_block    = "10.70.90.0"
 mesh_external_ip  = "199.170.132.46"
 # Add domains to the end
-meshdb_fqdn = "devdb.nycmesh.net,pgadmin.devdb.nycmesh.net,map.devdb.nycmesh.net,adminmap.devdb.nycmesh.net,los-backend.devdb.nycmesh.net,los.devdb.nycmesh.net,forms.devdb.nycmesh.net"
+meshdb_fqdn = "devdb.nycmesh.net,map.devdb.nycmesh.net,adminmap.devdb.nycmesh.net,los-backend.devdb.nycmesh.net,los.devdb.nycmesh.net,forms.devdb.nycmesh.net"

--- a/terraform/prod1.tfvars
+++ b/terraform/prod1.tfvars
@@ -46,4 +46,4 @@ mesh_networkrange = "24"
 mesh_net_block    = "10.70.90.0"
 mesh_external_ip  = "199.170.132.45"
 # Add domains to the end
-meshdb_fqdn = "wiki.nycmesh.net,db.nycmesh.net,pgadmin.db.nycmesh.net,map.db.nycmesh.net,adminmap.db.nycmesh.net,los-backend.db.nycmesh.net,los.nycmesh.net,forms.nycmesh.net"
+meshdb_fqdn = "wiki.nycmesh.net,db.nycmesh.net,map.db.nycmesh.net,adminmap.db.nycmesh.net,los-backend.db.nycmesh.net,los.nycmesh.net,forms.nycmesh.net"


### PR DESCRIPTION
The subdomain is no longer used by MeshDB, so it can be removed, so we don't need a cert for it.