### PR TITLE
Log hostname with haproxy

### DIFF
--- a/ansible/roles/k8s-lb/templates/haproxy.cfg
+++ b/ansible/roles/k8s-lb/templates/haproxy.cfg
@@ -13,18 +13,18 @@ global
 	crt-base /etc/ssl/private
 
 	# See: https://ssl-config.mozilla.org/#server=haproxy&server-version=2.0.3&config=intermediate
-        ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
-        ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
-        ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+	ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+	ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+	ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
 
 defaults
 	log	global
 	mode	http
 	option	httplog
 	option	dontlognull
-        timeout connect 5000
-        timeout client  50000
-        timeout server  50000
+	timeout connect 5000
+	timeout client  50000
+	timeout server  50000
 	errorfile 400 /etc/haproxy/errors/400.http
 	errorfile 403 /etc/haproxy/errors/403.http
 	errorfile 408 /etc/haproxy/errors/408.http
@@ -36,13 +36,26 @@ defaults
 frontend meshdb
   bind {{ EXTERNAL_LISTEN_IP }}:80
   bind {{ EXTERNAL_LISTEN_IP }}:443 ssl crt /etc/haproxy/ssl/
+
+  # By default, pass reauests to k3s
   default_backend k8s
+
+  # Capture the first 32 chars of the hostname for logs
+  http-request capture req.hdr(Host) len 32
+
+  # Certbot HTTP challenge
   acl app_letsencrypt path_beg /.well-known/acme-challenge/
   use_backend be_letsencrypt if app_letsencrypt
+
+  # Stats uses a different backend
   acl app_grafana hdr(host) -i stats-new.nycmesh.net
   use_backend be_grafana if app_grafana
+
+  # Redirect wiki.mesh.nycmesh.net to wiki.nycmesh.net
   acl is_wiki_mesh hdr(host) -i wiki.mesh.nycmesh.net
   http-request redirect code 302 location https://wiki.nycmesh.net%[capture.req.uri] if is_wiki_mesh
+
+  # Redirect http to https
   http-request redirect scheme https unless { ssl_fc } OR app_letsencrypt
 
 backend k8s


### PR DESCRIPTION
- Log hostname in haproxy (captured headers are included in default `log-format`)
- Describe sections of the haproxy frontend config
- White space fixes