### PR TITLE
Add meshforms and meshdb to tracing

### DIFF
--- a/ansible/roles/k8s-cluster-helm/templates/datadog_agent.yaml.j2
+++ b/ansible/roles/k8s-cluster-helm/templates/datadog_agent.yaml.j2
@@ -12,8 +12,16 @@ spec:
     site: us5.datadoghq.com
     clusterName: {{ ENV_NAME }}
   features:
+    admissionController:
+      enabled: true
+      mutateUnlabelled: false
     apm:
       enabled: true
+      instrumentation:
+        enabled: true
+        enabledNamespaces:
+        - meshforms
+        - meshdb
     logCollection:
       enabled: true
       containerCollectAll: true


### PR DESCRIPTION
Need to re-enable tracing for these namespaces. In Dev3, the init containers took about 3.5 minutes to spin up.