### PR TITLE
Add env name to traces

### DIFF
--- a/ansible/roles/k8s-cluster-helm/templates/datadog_agent.yaml.j2
+++ b/ansible/roles/k8s-cluster-helm/templates/datadog_agent.yaml.j2
@@ -4,6 +4,13 @@ metadata:
   name: datadog
   namespace: datadog
 spec:
+  override:
+    nodeAgent:
+      containers:
+        trace-agent:
+          env:
+          - name: DD_APM_ENV
+            value: {{ ENV_NAME }}
   global:
     credentials:
       apiSecret:


### PR DESCRIPTION
I tested this by editing dev3 and it seems to work. This should tag our traces appropriately and hopefully get rid of the `env:none`