### PR TITLE
Remove meshdb 'map' domains

### DIFF
--- a/terraform/dev3.tfvars
+++ b/terraform/dev3.tfvars
@@ -46,4 +46,11 @@ mesh_net_block    = "10.70.90.0"
 mesh_external_ips = [
   "199.170.132.46",
 ]
-meshdb_fqdn = "devdb.nycmesh.net,map.devdb.nycmesh.net,adminmap.devdb.nycmesh.net,los-backend.devdb.nycmesh.net,los.devdb.nycmesh.net,forms.devdb.nycmesh.net,devmap.nycmesh.net"
+meshdb_fqdn = [
+  "devdb.nycmesh.net",
+  "adminmap.devdb.nycmesh.net",
+  "los-backend.devdb.nycmesh.net",
+  "los.devdb.nycmesh.net",
+  "forms.devdb.nycmesh.net",
+  "devmap.nycmesh.net",
+]

--- a/terraform/mesh_cluster/ansible.tf
+++ b/terraform/mesh_cluster/ansible.tf
@@ -34,7 +34,7 @@ resource "ansible_group" "lb" {
     INTERNAL_NETWORK_RANGE       = var.mesh_networkrange
     WORKER_IPS                   = join(";", var.mesh_ips)
     NODE_PORT                    = "80"
-    MESHDB_FQDN                  = var.meshdb_fqdn
+    MESHDB_FQDN                  = join(",", var.meshdb_fqdn)
     MESH_DG                      = var.mesh_gateway
     DATADOG_API_KEY              = var.DATADOG_API_KEY
     DATADOG_SITE                 = var.DATADOG_SITE

--- a/terraform/mesh_cluster/vars.tf
+++ b/terraform/mesh_cluster/vars.tf
@@ -71,8 +71,8 @@ variable "mesh_external_ips" {
 }
 
 variable "meshdb_fqdn" {
-  type        = string
-  description = "fqdn meshdb should be responding to"
+  type        = list(string)
+  description = "FQDNs the cluster should respond to"
 }
 
 variable "vm_nic" {

--- a/terraform/prod1.tfvars
+++ b/terraform/prod1.tfvars
@@ -47,4 +47,8 @@ mesh_net_block    = "10.70.90.0"
 mesh_external_ips = [
   "199.170.132.45",
 ]
-meshdb_fqdn = "wiki.nycmesh.net,wiki.mesh.nycmesh.net,los-backend.db.nycmesh.net"
+meshdb_fqdn = [
+  "wiki.nycmesh.net",
+  "wiki.mesh.nycmesh.net",
+  "los-backend.db.nycmesh.net",
+]

--- a/terraform/prod2.tfvars
+++ b/terraform/prod2.tfvars
@@ -46,4 +46,12 @@ mesh_net_block    = "10.70.100.0"
 mesh_external_ips = [
   "23.158.16.22",
 ]
-meshdb_fqdn = "db.nycmesh.net,map.db.nycmesh.net,adminmap.db.nycmesh.net,los.nycmesh.net,forms.nycmesh.net,stats-new.nycmesh.net,map.nycmesh.net,stats.nycmesh.net"
+meshdb_fqdn = [
+  "db.nycmesh.net",
+  "adminmap.db.nycmesh.net",
+  "los.nycmesh.net",
+  "forms.nycmesh.net",
+  "stats-new.nycmesh.net",
+  "stats.nycmesh.net",
+  "map.nycmesh.net",
+]

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -105,8 +105,8 @@ variable "mesh_external_ips" {
 }
 
 variable "meshdb_fqdn" {
-  type        = string
-  description = "fqdn meshdb should be responding to"
+  type        = list(string)
+  description = "FQDNs the cluster should respond to"
 }
 
 variable "vm_nic" {


### PR DESCRIPTION
- Remove `map.{db,devdb}.nycmesh.net` because they aren't needed anymore
- Turn the domain string thing into a list so diffs look better