### PR TITLE
Simplify dd logs setup

### DIFF
--- a/ansible/roles/monitoring/files/journald.d_conf.yaml
+++ b/ansible/roles/monitoring/files/journald.d_conf.yaml
@@ -1,3 +1,0 @@
-logs:
-  - type: journald
-    path: /var/log/journal/

--- a/ansible/roles/monitoring/tasks/main.yaml
+++ b/ansible/roles/monitoring/tasks/main.yaml
@@ -6,20 +6,12 @@
     datadog_site: "{{ DATADOG_SITE }}"
     datadog_config:
       logs_enabled: true
-
-- name: Adding dd-agent to systemd-journal 
-  ansible.builtin.user:
-    name: dd-agent
-    groups: systemd-journal
-    append: true
-    create_home: false
-
-- name: Datadog logging config
-  ansible.builtin.copy:
-    src: files/journald.d_conf.yaml
-    dest: /etc/datadog-agent/conf.d/journald.d/conf.yaml
-    owner: dd-agent
-    group: dd-agent
+    datadog_additional_groups: "systemd-journal"
+    datadog_checks:
+      journald:
+        logs:
+          - type: journald
+            path: /var/log/journal/
 
 - name: Reload datadog
   ansible.builtin.systemd_service:


### PR DESCRIPTION
Cleanup the dd logging setup by using the role instead of setting it up manually.