### PR TITLE
Add Dev Wiki to DNS for Dev box

### DIFF
--- a/terraform/dev3.tfvars
+++ b/terraform/dev3.tfvars
@@ -50,6 +50,7 @@ mesh_external_ips = [
   "199.170.132.46",
 ]
 meshdb_fqdn = [
+  "devwiki.mesh.nycmesh.net",
   "devdb.nycmesh.net",
   "adminmap.devdb.nycmesh.net",
   "los-backend.devdb.nycmesh.net",


### PR DESCRIPTION
With the instruction of James I'm adding an additional DNS alternative name to the Dev box so invalid cert errors stop showing up when going to https://devwiki.mesh.nycmesh.net/