### PR TITLE
Disable apm in non-prod

### DIFF
--- a/ansible/roles/k8s_cluster_helm/templates/datadog_agent.yaml.j2
+++ b/ansible/roles/k8s_cluster_helm/templates/datadog_agent.yaml.j2
@@ -22,6 +22,7 @@ spec:
     admissionController:
       enabled: true
       mutateUnlabelled: false
+{% if "prod" in ENV_NAME %}
     apm:
       enabled: true
       instrumentation:
@@ -29,6 +30,7 @@ spec:
         enabledNamespaces:
         - meshforms
         - meshdb
+{% endif %}
     logCollection:
       enabled: true
       containerCollectAll: true


### PR DESCRIPTION
This is a stop-gap until I can find the time to replace single-step instrumentation in meshdb with something less taxing. Single-step instrumentation has caused a number of issues, including
- slow start times
- slow response times
- (suspected) exacerbating issues with disk latency in dev.