### PR TITLE
Delete single step APM instrumentation

### DIFF
--- a/ansible/roles/k8s_cluster_helm/templates/datadog_agent.yaml.j2
+++ b/ansible/roles/k8s_cluster_helm/templates/datadog_agent.yaml.j2
@@ -24,15 +24,6 @@ spec:
     admissionController:
       enabled: true
       mutateUnlabelled: false
-{% if "prod" in ENV_NAME %}
-    apm:
-      enabled: true
-      instrumentation:
-        enabled: true
-        enabledNamespaces:
-        - meshforms
-        - meshdb
-{% endif %}
     logCollection:
       enabled: true
       containerCollectAll: true


### PR DESCRIPTION
Now that we have instrumentation on meshdb itself we don't need to have this single step malarkey.