### PR TITLE
Add tsig_main_dns_ip

### DIFF
--- a/.github/workflows/deploy_k8s_cluster.yaml
+++ b/.github/workflows/deploy_k8s_cluster.yaml
@@ -20,6 +20,7 @@ env:
   TF_VAR_longhorn_passphrase: ${{ secrets.LONGHORN_PASSPHRASE }}
   TF_VAR_tsig_key: ${{ secrets.TSIG_KEY }}
   TF_VAR_tsig_key_name: "k8s.lb.${{ vars.ENV_NAME }}"
+  TF_VAR_tsig_main_dns_ip: "${{ vars.TSIG_DNS_IP }}"
   # Credentials for deployment to AWS
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/ansible/roles/k8s_lb/tasks/main.yaml
+++ b/ansible/roles/k8s_lb/tasks/main.yaml
@@ -101,7 +101,7 @@
     certbot_get_cert_for_domain: "{{ internal_apps_fqdn }}"
     certbot_tsig_key: "{{ tsig_key }}"
     certbot_tsig_key_name: "{{ tsig_key_name }}"
-    certbot_main_auth_dns_server: "199.170.132.47"
+    certbot_main_auth_dns_server: "{{ tsig_main_dns_ip }}"
 
 - name: Set net.ipv4.ip_forward
   ansible.posix.sysctl:

--- a/terraform/cluster.tf
+++ b/terraform/cluster.tf
@@ -34,4 +34,5 @@ module "some_mesh_cluster" {
   vm_nic                        = var.vm_nic
   tsig_key                      = var.tsig_key
   tsig_key_name                 = var.tsig_key_name
+  tsig_main_dns_ip              = var.tsig_main_dns_ip
 }

--- a/terraform/mesh_cluster/ansible.tf
+++ b/terraform/mesh_cluster/ansible.tf
@@ -44,6 +44,7 @@ resource "ansible_group" "lb" {
     BIRD_OSPF_COST               = var.bird_ospf_cost
     tsig_key                     = var.tsig_key
     tsig_key_name                = var.tsig_key_name
+    tsig_main_dns_ip             = var.tsig_main_dns_ip
   }
 }
 

--- a/terraform/mesh_cluster/vars.tf
+++ b/terraform/mesh_cluster/vars.tf
@@ -174,3 +174,8 @@ variable "tsig_key_name" {
   description = "name of the TSIG key for internal certs"
   sensitive   = true
 }
+
+variable "tsig_main_dns_ip" {
+  type        = string
+  description = "IP of the authoritative DNS server to use for tsig"
+}

--- a/terraform/prod2.tfvars
+++ b/terraform/prod2.tfvars
@@ -57,5 +57,5 @@ meshdb_fqdn = [
 ]
 
 internal_apps_fqdn = [
-  "jamesinternalprod2.mesh.nycmesh.net",
+  "jamesinternalprodtwo.mesh.nycmesh.net",
 ]

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -190,3 +190,8 @@ variable "tsig_key_name" {
   description = "name of the TSIG key for internal certs"
   sensitive   = true
 }
+
+variable "tsig_main_dns_ip" {
+  type        = string
+  description = "IP of the authoritative DNS server to use for tsig"
+}


### PR DESCRIPTION
Avoid hardcoding the authoritative DNS server IP so that it can be different between the environments.

This is so it is easier to make the inside and outside IPs point to the same servers for servers using TSIG.